### PR TITLE
Add description about CISM in the documentation

### DIFF
--- a/doc/configurations/cism.rst
+++ b/doc/configurations/cism.rst
@@ -3,6 +3,8 @@
 Land ice
 ======
 
+**Note! The CISM coupling is under development and not yet a scientifically supported option in NorESM.**
+
 CISM
 ''''
 
@@ -24,4 +26,7 @@ The CISM model uses forcing files from the land model, CLM. To use NorESM2 histo
   hist_fincl2 = 'QRUNOFF', 'SOILLIQ', 'SOILICE', 'SOILWATER_10CM', 'TSA', 'TSL', 'GPP', 'AR', 'HR'
   hist_fincl3 = 'FIRA', 'FIRE', 'FSH', 'EFLX_LH_TOT', 'QSNOMELT', 'QSNOFRZ', 'QSOIL', 'QICE', 'QICE_MELT', 'FSA', 'FSR', 'TOPO_COL', 'FSDS', 'FLDS', 'LWdown', 'RAIN', 'SNOW', 'TSA', 'TG', 'H2OSNO'
   hist_dov2xy = .true., .true., .false.
+
+
+**Recoupling CLM5 with NorESM2**
 

--- a/doc/configurations/cism.rst
+++ b/doc/configurations/cism.rst
@@ -1,0 +1,27 @@
+.. _cism:
+
+Land ice
+======
+
+CISM
+''''
+
+
+Spin up of CLM5 
+^^^^^^
+A long spin up is required for running NorESM2 with CISM activated
+
+
+
+
+**Running CISM stand alone with NorESM2 forcing data**
+
+The CISM model uses forcing files from the land model, CLM. To use NorESM2 history files as the forcing, these lines need to be included in `user_nl_clm` ::
+
+  hist_nhtfrq = 0, -24, 0
+  hist_mfilt  = 1, 5, 1
+  hist_fincl1 = 'FERT_TO_SMINN','NFIX_TO_SMINN','LITFIRE','LITR1C_TO_SOIL1C','LITR2C_TO_SOIL1C','LITR3C_TO_SOIL2C','M_LEAFC_TO_LITTER','M_FROOTC_TO_LITTER','M_LIVESTEMC_TO_LITTER','M_DEADSTEMC_TO_LITTER','M_LIVECROOTC_TO_LITTER','M_DEADCROOTC_TO_LITTER','FIRA', 'FIRE_ICE', 'FSH_ICE', 'EFLX_LH_TOT_ICE', 'QSNOMELT_ICE', 'QSNOFRZ_ICE', 'QSOIL_ICE', 'QICE', 'QICE_MELT', 'FSA', 'FSR_ICE', 'TOPO_COL_ICE', 'FSDS', 'FLDS', 'LWdown', 'RAIN_ICE', 'SNOW_ICE', 'TSA_ICE', 'TG_ICE', 'H2OSNO_ICE', 'ICE_MODEL_FRACTION'
+  hist_fincl2 = 'QRUNOFF', 'SOILLIQ', 'SOILICE', 'SOILWATER_10CM', 'TSA', 'TSL', 'GPP', 'AR', 'HR'
+  hist_fincl3 = 'FIRA', 'FIRE', 'FSH', 'EFLX_LH_TOT', 'QSNOMELT', 'QSNOFRZ', 'QSOIL', 'QICE', 'QICE_MELT', 'FSA', 'FSR', 'TOPO_COL', 'FSDS', 'FLDS', 'LWdown', 'RAIN', 'SNOW', 'TSA', 'TG', 'H2OSNO'
+  hist_dov2xy = .true., .true., .false.
+

--- a/doc/configurations/configurations.rst
+++ b/doc/configurations/configurations.rst
@@ -15,5 +15,6 @@ Running NorESM2
    amips.rst
    omips.rst
    clm.rst
+   cism.rst
    ensemble_runs.rst
    nudged_simulations.rst

--- a/doc/model-description/atm_model.rst
+++ b/doc/model-description/atm_model.rst
@@ -1,6 +1,6 @@
 .. _atm_model:
 
-The atmosphere model
+The atmosphere model, CAM6-Nor
 =============================
 
 The atmospheric model component of NorESM2, **CAM6-Nor**, (Seland et al., in review for GMD) is built on the CAM6 version from CESM2.1, but with particulate aerosols and the aerosol-radiation-cloud interaction parameterisation from NorESM1 and NorESM1.2 as described by Kirkevåg et al. (2013, 2018). NorESM2-specific changes to model physics and dynamics which are not aerosol related, are described by Toniazzo et al. (2019) and Toniazzo et al. (in prep.). The latest updates in the aerosol modules (that is, the changes between NorESM1.2 and NorESM2) are described by Olivié et al. (in prep.).

--- a/doc/model-description/atm_model.rst
+++ b/doc/model-description/atm_model.rst
@@ -1,6 +1,6 @@
 .. _atm_model:
 
-The atmosphere model, CAM6-Nor
+The atmosphere model; CAM6-Nor
 =============================
 
 The atmospheric model component of NorESM2, **CAM6-Nor**, (Seland et al., in review for GMD) is built on the CAM6 version from CESM2.1, but with particulate aerosols and the aerosol-radiation-cloud interaction parameterisation from NorESM1 and NorESM1.2 as described by Kirkevåg et al. (2013, 2018). NorESM2-specific changes to model physics and dynamics which are not aerosol related, are described by Toniazzo et al. (2019) and Toniazzo et al. (in prep.). The latest updates in the aerosol modules (that is, the changes between NorESM1.2 and NorESM2) are described by Olivié et al. (in prep.).

--- a/doc/model-description/cism_model.rst
+++ b/doc/model-description/cism_model.rst
@@ -1,5 +1,5 @@
 .. _cism_model
-The land ice model, CISM
+The land ice model; CISM
 =========
 
 

--- a/doc/model-description/cism_model.rst
+++ b/doc/model-description/cism_model.rst
@@ -1,0 +1,10 @@
+.. _cism_model
+The land ice model, CISM
+=========
+
+
+
+
+
+References
+^^^^^

--- a/doc/model-description/coupler.rst
+++ b/doc/model-description/coupler.rst
@@ -1,6 +1,6 @@
 .. _coupler:
 
-The coupler, CIME
+The coupler; CIME
 ================
 
 The state and flux exchanges between model components and software infrastructure for configuring, building and execution of model experiments is handled by the CESM2 coupler Common Infrastructure for Modeling the Earth (CIME; Danabasoglu et al., 2019). Among the common utility functions CIME provides is the  estimation of solar zenith angle. In NorESM2, this utility function is modified with associated changes in atmosphere, land and sea ice components, ensuring that all albedo calculations use zenith angle averaged over the components time-step instead of instantaneous angles.

--- a/doc/model-description/lnd_model.rst
+++ b/doc/model-description/lnd_model.rst
@@ -1,6 +1,6 @@
 .. _lnd_model:
 
-The land model
+The land model, CLM5
 ===================
 The NorESM2 employs the latest version of "Community Land Model" (CLM5; Lawrence et al., 2019) as the land component. In the CLM5, Biogeophysical and biogeochemical processes are simulated for each subgrid land unit, column, and plant functional type (PFT) independently and each subgrid unit maintains its own prognostic variables. The same atmospheric forcing is used to force all subgrid units within a grid cell. The surface variables and fluxes required by the atmosphere are obtained by averaging the subgrid quantities weighted by their fractional areas. The processes simulated include:
 

--- a/doc/model-description/lnd_model.rst
+++ b/doc/model-description/lnd_model.rst
@@ -1,6 +1,6 @@
 .. _lnd_model:
 
-The land model, CLM5
+The land model; CLM5
 ===================
 The NorESM2 employs the latest version of "Community Land Model" (CLM5; Lawrence et al., 2019) as the land component. In the CLM5, Biogeophysical and biogeochemical processes are simulated for each subgrid land unit, column, and plant functional type (PFT) independently and each subgrid unit maintains its own prognostic variables. The same atmospheric forcing is used to force all subgrid units within a grid cell. The surface variables and fluxes required by the atmosphere are obtained by averaging the subgrid quantities weighted by their fractional areas. The processes simulated include:
 

--- a/doc/model-description/model-description.rst
+++ b/doc/model-description/model-description.rst
@@ -13,6 +13,7 @@ NorESM2 Model Description
    ocn_bgc_model.rst
    sea_ice_model.rst
    lnd_model.rst
+   cism_model.rst
    coupler.rst
    refs.rst
    

--- a/doc/model-description/ocn_bgc_model.rst
+++ b/doc/model-description/ocn_bgc_model.rst
@@ -1,6 +1,6 @@
 .. _ocn_bgc_model:
 
-The ocean BGC model, iHAMOCC
+The ocean BGC model; iHAMOCC
 =======================================
 
 The ocean biogeochemistry (BGC) component **iHAMOCC** (isopycnic coordinate HAMburg Ocean Carbon Cycle model) is an updated version of the ocean biogeochemistry module used in NorESM1. The iHAMOCC is based on the the HAMOCC5.1 model developed in Max-Planck Institute of Meteorology (Maier-Reimer et al., 2005) and was later modified for an isopycnal-coordinate ocean general circulation model (Assmann et al., 2010).

--- a/doc/model-description/ocn_bgc_model.rst
+++ b/doc/model-description/ocn_bgc_model.rst
@@ -1,6 +1,6 @@
 .. _ocn_bgc_model:
 
-The ocean BGC model
+The ocean BGC model, iHAMOCC
 =======================================
 
 The ocean biogeochemistry (BGC) component **iHAMOCC** (isopycnic coordinate HAMburg Ocean Carbon Cycle model) is an updated version of the ocean biogeochemistry module used in NorESM1. The iHAMOCC is based on the the HAMOCC5.1 model developed in Max-Planck Institute of Meteorology (Maier-Reimer et al., 2005) and was later modified for an isopycnal-coordinate ocean general circulation model (Assmann et al., 2010).

--- a/doc/model-description/ocn_model.rst
+++ b/doc/model-description/ocn_model.rst
@@ -1,6 +1,6 @@
 .. _ocn_model:
 
-The ocean model, BLOM
+The ocean model; BLOM
 =====================
 
 

--- a/doc/model-description/ocn_model.rst
+++ b/doc/model-description/ocn_model.rst
@@ -1,6 +1,6 @@
 .. _ocn_model:
 
-The ocean model
+The ocean model, BLOM
 =====================
 
 

--- a/doc/model-description/sea_ice_model.rst
+++ b/doc/model-description/sea_ice_model.rst
@@ -1,4 +1,4 @@
-.. _cea_ice_model:
+.. _cea_ice_model; CICE:
 
 The sea-ice model
 ======================

--- a/doc/model-description/sea_ice_model.rst
+++ b/doc/model-description/sea_ice_model.rst
@@ -1,6 +1,6 @@
-.. _cea_ice_model; CICE:
+.. _cea_ice_model:
 
-The sea-ice model
+The sea-ice model; CICE
 ======================
 
 The sea ice model component is based upon version 5.1.2 of the **CICE** sea ice model of Hunke et al. (2015). A NorESM2-specific change is including the effect of wind drift of snow into ocean following Lecomte et al. (2013), as described in Bentsen et al. (in prep). The NorESM version is also equipped with the possibility to modify snow density and snow thermal conductivity in the namelist. 


### PR DESCRIPTION
I have added two rather empty "cism files" to the documentation. @hgoelzer will include content later on. 

1) How to run CISM, generate forcing data, run CISM stand alone, coupling with NorESM, compsets etc: NorESM/doc/configurations/cism.rst

2) A model description with some important links and references: NorESM/doc/model-description(cism_model.rst)

Also included the names of the other model components in the heading of the files