### PR TITLE
add test for --user_mech_infile

### DIFF
--- a/cime_config/testmods_dirs/allactive/mychem/shell_commands
+++ b/cime_config/testmods_dirs/allactive/mychem/shell_commands
@@ -1,0 +1,8 @@
+rm -f $CIMEROOT/../components/cam/chem_proc/campp
+
+cp $CIMEROOT/../components/cam/src/chemistry/pp_trop_mam_oslo/chem_mech.in my_chem_mech.in
+sed -i 's/2.9/8.8/' my_chem_mech.in
+sed -i 's/BEGSIM/*BEGSIM/' my_chem_mech.in
+sed -i 's/ENDSIM/*ENDSIM/' my_chem_mech.in
+
+./xmlchange --append CAM_CONFIG_OPTS="--usr_mech_infile `pwd`/my_chem_mech.in"


### PR DESCRIPTION
Summary: Test for checking functionality of --usr_mech_infile option for CAM_CONFIG_OPTS

Contributors: @annlew

Reviewers: @gold2718

Purpose of changes: Test to catch chemistry preprocessor failure

Github PR URL:

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Issues addressed by this PR:
cam_chempp issue with usr_mech_infile when path to compiler is too long (https://github.com/NorESMhub/CAM/issues/160)

addresses https://github.com/NorESMhub/CAM/issues/160