### PR TITLE
noresm2_5_alpha05: fix dglc%noevolve restart problem

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -75,7 +75,7 @@ required = True
 
 [cdeps]
 protocol = git
-tag = cdeps1.0.46
+tag = cdeps1.0.50
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
 externals =  Externals_CDEPS.cfg

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -75,7 +75,7 @@ required = True
 
 [cdeps]
 protocol = git
-tag = cdeps1.0.50
+tag = cdeps1.0.51
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
 externals =  Externals_CDEPS.cfg


### PR DESCRIPTION
This PR only changes cdeps DGLC functionality for dglc%noevolve and resolves a restart problem across year boundaries for fully coupled runs.