### PR TITLE
noresm2_5_alpha09: Update CTSM, BLOM config in compsets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@ fxDONOTUSEurl = https://github.com/MCSclimate/MCT
 [submodule "ccs_config"]
 path = ccs_config
 url = https://github.com/NorESMhub/ccs_config_noresm.git
-fxtag = ccs_config_noresm0.0.38
+fxtag = ccs_config_noresm0.0.39
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/ccs_config_noresm.git
 
@@ -115,7 +115,7 @@ fxDONOTUSEurl = https://github.com/NorESMhub/CISM-wrapper
 [submodule "clm"]
 path = components/clm
 url = https://github.com/NorESMhub/CTSM
-fxtag = ctsm5.3.11-noresm_v1
+fxtag = ctsm5.3.11-noresm_v2
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/CTSM
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@ fxDONOTUSEurl = https://github.com/MCSclimate/MCT
 [submodule "ccs_config"]
 path = ccs_config
 url = https://github.com/NorESMhub/ccs_config_noresm.git
-fxtag = ccs_config_noresm0.0.39
+fxtag = ccs_config_noresm0.0.38
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/ccs_config_noresm.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,47 @@
 =============================================================
+Tag name: noresm2_5_alpha09
+Date: 06 Feb 2025
+One-line Summary: Update BLOM to hybrid coords in compsets, update CTSM 
+
+ccs_config		: https://github.com/NorESMhub/ccsm_config_noresm/ccs_config_noresm0.0.38
+cime			: https://github.com/NorESMhub/come/cime6.1.28_noresm_v0
+share			: https://github.com/NorESMhub/NorESM_share/share1.1.2_noresm_v0
+components/blom		: https://github.com/NorESMhub/BLOM/dev1.7.0
+components/cam		: https://github.com/NorESMhub/CAM/noresm2_5_014_cam6_3_158
+components/cdeps	: https://github.com/ESCOMP/CDEPS.git/cdeps1.0.51
+components/cice		: https://github.com/NorESMhub/NorESM_CICE/cesm_cice6_5_0_20240702_noresm_v1
+components/cism		: https://github.com/NorESMhub/CISM-wrapper/CISM_wrapper/cismwrap_2_2_002_noresm_v1
+components/clm		: https://github.com/ESCOMP/CDEPS.git/CLM/ctsm5.3.11-noresm_v2
+components/cmeps	: https://github.com/ESCOMP/CMEPS.git/cmeps1.0.20_noresm_v0
+components/mosart	: https://github.com/ESCOMP/CDEPS.git/MOSART/mosart1.1.02
+components/ww3		: https://github.com/NorESMhub/WW3_interface/ww3_interface_noresm0.0.15
+libraries/mct		: https://github.com/MCSclimate/MCT/MCT_2.11.0
+libraries/parallelio    : https://github.com/NCAR/ParallelIO/pio2_6_2
+
+Answer Changes introduced with this tag when compared to noresm2_5_alpha08d
+    YES
+
+Problems identified as part of testing:
+
+  Baseline failures (expected):
+    All with %BLOM
+
+  Restart failure:
+  ERR_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio (Overall: FAIL) details:
+    FAIL ERR_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio COMPARE_base_rest
+  ERS_D_Ld4.ne30pg3_tn14.N2N1850.betzy_intel.allactive-defaultio (Overall: FAIL) details:
+    FAIL ERS_D_Ld4.ne30pg3_tn14.N2N1850.betzy_intel.allactive-defaultio COMPARE_base_rest
+  Reason:
+     cam.h0a.0001-01-XX-00000.nc.base.cprnc.out: field SFDMS is not the same on restart (see https://github.com/NorESMhub/NorESM/issues/625)
+
+=============================================================
+
+
+
+
+
+
+=============================================================
 Tag name: noresm2_5_alpha08b
 Date: 24 Nov 2024
 One-line Summary: Update CAM, CTSM and add git-fleximod

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -40,24 +40,24 @@
 
   <compset>
     <alias>N1850</alias>
-    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%SP_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
   <compset>
     <alias>N1850clmbgc</alias>
-    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%BGC-CROP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%BGC-CROP_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
   <compset>
     <alias>N1850fates-sp</alias>
-    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-SP_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
   <compset>
     <alias>N1850fates-nocomp</alias>
-    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-NOCOMP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-NOCOMP_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
   <compset>
     <alias>N1850mam4</alias>
-    <lname>1850_CAM70%LT%GHGMAM4_CLM60%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+    <lname>1850_CAM70%LT%GHGMAM4_CLM60%SP_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
   <!-- BG compsets: evolving ice sheet -->
@@ -75,6 +75,12 @@
   <compset>
      <alias>J1850G</alias>
      <lname>1850_DATM%CRUv7_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
+  </compset>
+
+  <!-- fully coupled without hybrid coordinate in BLOM for testing-->
+  <compset>
+    <alias>N1850nohyb</alias>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
   <entries>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -79,7 +79,7 @@
 
   <!-- fully coupled without hybrid coordinate in BLOM for testing-->
   <compset>
-    <alias>N1850nohyb</alias>
+    <alias>N2N1850</alias>
     <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -56,7 +56,7 @@
       <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
-  <test name="ERS_D_Ld5" grid="ne30pg3_tn14" compset="N1850nohyb" testmods="allactive/defaultio">
+  <test name="ERS_D_Ld4" grid="ne30pg3_tn14" compset="N1850nohyb" testmods="allactive/defaultio">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -56,4 +56,12 @@
       <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
+  <test name="ERS_D_Ld5" grid="ne30pg3_tn14" compset="N1850nohyb" testmods="allactive/defaultio">
+    <machines>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
 </testlist>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -56,7 +56,7 @@
       <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
-  <test name="ERS_D_Ld4" grid="ne30pg3_tn14" compset="N1850nohyb" testmods="allactive/defaultio">
+  <test name="ERS_D_Ld4" grid="ne30pg3_tn14" compset="N2N1850" testmods="allactive/defaultio">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>


### PR DESCRIPTION
Summary: Update CTSM to include megan refactor, blom compsets


Contributors: mvdebolskiy, 
Reviewers: matsbn, gold2718
Purpose of changes: 
Github PR URL: 
Changes made to build system: None
Changes made to the namelist: None
Changes to the defaults for the boundary datasets: None
Substantial timing or memory changes: None

Testing: See test results:

All tests (not expected to fail) pass.


Issues addressed by this PR:
fixes NorESMhub/NorESM#582 