### PR TITLE
Add reduced output usermod for dev simulations

### DIFF
--- a/cime_config/usermods_dirs/reduced_out_devsim/include_user_mods
+++ b/cime_config/usermods_dirs/reduced_out_devsim/include_user_mods
@@ -1,0 +1,1 @@
+../../../components/clm/cime_config/usermods_dirs/reduced_output_fates


### PR DESCRIPTION
Add usermod dir containing reduced output configs for every component:

- [x] CLM
- [ ] CAM
- [x] BLOM

Example for creating new case :
```
$SRCROOT/create_newcase --case $CASDIR --compset N1850fates-sp  --res ne30pg3_tn14  --run-unsupported --machine betzy --project $PROJECt --walltime 00:32:00 --user-mods-dir $CRSCROOT/cime_config/usermods_dirs/reduced_out_devsim/
```