### PR TITLE
noresm3_0_beta03b: Updates to BLOM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,7 +74,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share.git
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = v1.12.10
+fxtag = v1.12.11
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -74,7 +74,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share.git
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = v1.12.7
+fxtag = v1.12.9
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -74,7 +74,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share.git
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = v1.12.9
+fxtag = v1.12.10
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@ Date:
 One-line Summary: Support high-order remapping to z-levels for ocean diagnostic output
 
 Details:
- - Update blom to v1.12.10
+ - Update blom to v1.12.11
 
 Component tags used in this tag:
 
@@ -13,7 +13,7 @@ Component tags used in this tag:
  - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.53
  - cime       : NorESMhub/cime              : cime6.1.73_noresm_v0
  - share      : NorESMHub/NorESM_share      : share1.1.9_noresm_v0
- - blom       : NorESMhub/BLOM              : v1.12.10
+ - blom       : NorESMhub/BLOM              : v1.12.11
  - cam        : NorESMhub/CAM               : noresm3_0_018_cam6_4_085
  - cdeps      : NorESMhub/CDEPS             : cdeps1.0.70_noresm_v7
  - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_0_20250522_v2

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@ Date:
 One-line Summary: Support high-order remapping to z-levels for ocean diagnostic output
 
 Details:
- - Update blom to v1.12.9
+ - Update blom to v1.12.10
 
 Component tags used in this tag:
 
@@ -13,7 +13,7 @@ Component tags used in this tag:
  - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.53
  - cime       : NorESMhub/cime              : cime6.1.73_noresm_v0
  - share      : NorESMHub/NorESM_share      : share1.1.9_noresm_v0
- - blom       : NorESMhub/BLOM              : v1.12.9
+ - blom       : NorESMhub/BLOM              : v1.12.10
  - cam        : NorESMhub/CAM               : noresm3_0_018_cam6_4_085
  - cdeps      : NorESMhub/CDEPS             : cdeps1.0.70_noresm_v7
  - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_0_20250522_v2

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,43 @@
+==============================================================
+
+Tag name: noresm3_0_beta03b
+Date:
+One-line Summary: Support high-order remapping to z-levels for ocean diagnostic output
+
+Details:
+ - Update blom to v1.12.9
+
+Component tags used in this tag:
+
+ - parallelio : NCAR/ParallelIO             : pio2_6_2
+ - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.53
+ - cime       : NorESMhub/cime              : cime6.1.73_noresm_v0
+ - share      : NorESMHub/NorESM_share      : share1.1.9_noresm_v0
+ - blom       : NorESMhub/BLOM              : v1.12.9
+ - cam        : NorESMhub/CAM               : noresm3_0_018_cam6_4_085
+ - cdeps      : NorESMhub/CDEPS             : cdeps1.0.70_noresm_v7
+ - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_0_20250522_v2
+ - cism       : NorESMhub/CISM-wrapper      : cismwrap_2_2_007_noresm_v0
+ - clm        : NorESMhub/CTSM              : ctsm5.3.045_noresm_v13
+    - fates   : NorESMhub/fates             : sci.1.85.1_api.40.0.0_noresm_v5
+ - cmeps      : NorESMhub/CMEPS             : cmeps1.0.39_noresm_v8
+ - mosart     : NorESMhub/MOSART            : mosart1.1.12_noresm_v0
+ - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.18
+ - pycect     : NCAR/PyCECT                 : 3.2.2
+
+Bugs fixed:
+
+Describe any changes made to scripts/build system: NA
+
+Describe any substantial timing or memory changes: NA
+
+Code merged by: Tomas Torsvik
+
+Code reviewed by:
+
+Summary of pre-tag testing:
+
+Summarize any change to answers:
 
 ==============================================================
 
@@ -21,7 +61,7 @@ Details:
    - Update fates to sci.1.85.1_api.40.0.0_noresm_v5
  - Update ccs_config to ccs_config_noresm0.0.53
    - Changes to reduce number of random ucx and hcoll fails
-   - Make devel and normal queues more distinct 
+   - Make devel and normal queues more distinct
 
 Component tags used in this tag:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,15 @@
 ==============================================================
 
 Tag name: noresm3_0_beta03b
-Date:
+Date: 21.10.2025
 One-line Summary: Support high-order remapping to z-levels for ocean diagnostic output
 
 Details:
  - Update blom to v1.12.11
+   - Use high-order vertical reconstructions for remapping to diagnostic z-levels
+   - Include changes needed for CAM computing enthalpy -> mediator -> BLOM
+   - Remove outdated compset NOIIAOC20TR from list of standard tests
+ - Set NTASK_OCN=500 for grid=ne16pg3_tn14; pesize=X1
 
 Component tags used in this tag:
 
@@ -25,7 +29,7 @@ Component tags used in this tag:
  - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.18
  - pycect     : NCAR/PyCECT                 : 3.2.2
 
-Bugs fixed:
+Bugs fixed: NA
 
 Describe any changes made to scripts/build system: NA
 
@@ -33,9 +37,18 @@ Describe any substantial timing or memory changes: NA
 
 Code merged by: Tomas Torsvik
 
-Code reviewed by:
+Code reviewed by: Mats Bentsen, Steve Goldhaber, Mariana Vertenstein
 
 Summary of pre-tag testing:
+ - prealpha_noresm : all test PASS
+   - DIFF compared with noresm3_0_beta03a for all NorESM compsets
+ - aux_blom_noresm : 4 expected FAIL
+     ERP_Ld3_P256.T62_tn14.NOINYOC.betzy_gnu
+     ERP_Ld3_P256.T62_tn14.NOINYOC.betzy_intel
+     ERS_Ld3.T62_tn14_wtn14nw.NOINY_WW3.betzy_gnu.blom-wavice
+     SMS_D_Ld1.T62_tn14_wtn14nw.NOINYOC_WW3.betzy_gnu.blom-wavice
+   - DIFF compared with noresm3_0_beta03a for all test using hybrid
+	vertical coordinates
 
 Summarize any change to answers:
 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -277,7 +277,7 @@
                 <ntasks_lnd>-6</ntasks_lnd>
                 <ntasks_rof>-12</ntasks_rof>
                 <ntasks_ice>-6</ntasks_ice>
-                <ntasks_ocn>-2</ntasks_ocn>
+                <ntasks_ocn>500</ntasks_ocn>
                 <ntasks_glc>-12</ntasks_glc>
                 <ntasks_wav>-12</ntasks_wav>
                 <ntasks_cpl>-12</ntasks_cpl>


### PR DESCRIPTION
A minor update to BLOM, that enables support for enthalpy and modifies diagnostic output.
Also include update to `config_pes.xml` to set NTASKS_OCN=500 by default for the grid combination `a%ne16np4.pg3.+l%ne16np4.pg3.+oi%tnx1v4`.

- [x] BLOM tag `v1.12.11`
- [x] NTASK_OCN=500 in `config_pes.xml`
  - [x] Run 1 month with `--pecount X1` setting
- [x] Run tests and create baselines
  - [x] prealpha_noresm
  - [x] aux_blom_noresm
- [x] update ChangeLog