### PR TITLE
NorESM2_3_beta01

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.9
+tag = v1.6.12
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_noresm2_3_v1.0.0d
+tag = cam_noresm2_3_v1.0.0j
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -14,7 +14,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r5
+tag = cime5.6.10_NorESM2_3_r7
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.12
+tag = v1.6.13
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2020 The NorESM developers group
+Copyright (C) 2026 The NorESM developers group
 
 The NorESM developers group is currently affiliated to the following
 Institutions:

--- a/README.md
+++ b/README.md
@@ -4,21 +4,29 @@
 
 [![Documentation Status](https://readthedocs.org/projects/noresm-docs/badge/?version=noresm2)](https://noresm-docs.readthedocs.io/en/noresm2/?badge=noresm2)
 
-# The Norwegian Earth System Model version 2 (NorESM2)
+# The Norwegian Earth System Model version 2.3 (NorESM2)
 The **noresm2** branch contains the NorESM2.0.X documentation, code and configurations as used for most  <br />
 NorESM2-LM and NorESM2-MM CMIP6 simulations
 
 The NorESM-2.0 documentation: https://noresm-docs.readthedocs.io/en/noresm2/
 
 ## Releases in noresm2
+- [release-noresm2.1.3](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.1.3)
+- [release-noresm2.1.2](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.1.2)
+- [release-noresm2.1.1](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.1.1)
+- [release-noresm2.1.0](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.1.0)
+- [release-noresm2.0.10](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.10)
+- [release-noresm2.0.9](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.9)
+- [release-noresm2.0.8](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.8)
+- [release-noresm2.0.7](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.7)
 - [release-noresm2.0.6](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.6)
     - Release of NorESM2.0.6, 12th of December 2022
     - Available to reproduce CMIP6 results of NorESM2
-    - Updated BLOM : options for hybrid vertical coordinates, support for NUOPC driver, changes in model diagnostics 
-    - Updated CAM : corrected CCN and COSP diagnostics 
+    - Updated BLOM : options for hybrid vertical coordinates, support for NUOPC driver, changes in model diagnostics
+    - Updated CAM : corrected CCN and COSP diagnostics
     - Link to cism-wrapper repository on NorESMhub (instead of ESCOMP) : added CISM support, Greenland enabled compsets and usermod
     - Additional SSP5-3.4 compset and emission driven SSP compsets
-    - Modification in the archiving script for netcdf3 to netcdf4 conversion (uses ncks instead nccopy)		
+    - Modification in the archiving script for netcdf3 to netcdf4 conversion (uses ncks instead nccopy)
     - Updated NorESM2.0 documentation
 
 - [release-noresm2.0.5](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.5)
@@ -32,16 +40,16 @@ The NorESM-2.0 documentation: https://noresm-docs.readthedocs.io/en/noresm2/
     - Additional Fram and Betzy settings included.
 
 - [release-noresm2.0.3](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.3)
-    - Release of NorESM2.0.3, 7th of April 2021 
+    - Release of NorESM2.0.3, 7th of April 2021
     - Available to reproduce CMIP6 results of NorESM2
     - Betzy settings included.
 
 - [release-noresm2.0.2](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.2)
     - Release of NorESM2.0.2, 20th of July 2020
     - Available to reproduce CMIP6 results of NorESM2.
-    
+
 - [release-noresm2.0.1](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.1)
-    - NorESM2 version,  April  2020 
+    - NorESM2 version,  April  2020
     - Initial preliminary release of CMIP6 version.
 
 For a detailed description of all NorESM2.0.X releases, please see https://noresm-docs.readthedocs.io/en/noresm2/releases/
@@ -52,5 +60,5 @@ For the NorESM code base used in CMIP5, please see the **noresm1** branch.
 
 # Low-key discussion forum
 
-If you have questions or you can’t find the solution to a problem in the FAQs or in other parts of the documentation, please post question(s) here: 
+If you have questions or you can’t find the solution to a problem in the FAQs or in other parts of the documentation, please post question(s) here:
 https://github.com/NorESMhub/NorESM/discussions

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![Documentation Status](https://readthedocs.org/projects/noresm-docs/badge/?version=noresm2)](https://noresm-docs.readthedocs.io/en/noresm2/?badge=noresm2)
 
 # The Norwegian Earth System Model version 2.3 (NorESM2)
-The **noresm2** branch contains the NorESM2.0.X documentation, code and configurations as used for most  <br />
-NorESM2-LM and NorESM2-MM CMIP6 simulations
+The **noresm2_3_develop** branch contains the NorESM2.3.X code and configurations.
+
+NorESM2.3 is a technical development version of NorESM2 that includes a few bug fixes along with numerous code improvements from the NorESM2.1 release (NorESM tag release-noresm2.1.1). NorESM2.3 relies on the same case creation (including compsets), set up, build and run procedures as NorESM2.0, but will not generally produce the same model output.
 
 The NorESM-2.0 documentation: https://noresm-docs.readthedocs.io/en/noresm2/
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -271,6 +271,11 @@
     <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
   </compset>
 
+  <compset>
+    <alias>N1850MAM4</alias>
+    <lname>1850_CAM60%NORESM%MAM4_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+  </compset>
+
    <compset>
     <alias>N2000</alias>
     <lname>2000_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
@@ -328,6 +333,11 @@
   <compset>
     <alias>NCO2x4cmip6</alias>
     <lname>1850_CAM60%NORESM%4xCO2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+  </compset>
+
+  <compset>
+    <alias>NHISTMAM4</alias>
+    <lname>HIST_CAM60%NORESM%MAM4_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -82,6 +82,14 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
+  <test name="ERS_Ld5" grid="f19_tn14" compset="N1850MAM4" testmods="allactive/defaultio">
+    <machines>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30 </option>
+    </options>
+  </test>
   <test name="ERS_Ld5" grid="f19_tn14" compset="NHIST" testmods="allactive/defaultio">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
@@ -99,6 +107,14 @@
     </options>
   </test>
   <test name="PFS" grid="f19_tn14" compset="NHIST">
+    <machines>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
+  <test name="ERS_Ld5" grid="f19_tn14" compset="NHISTMAM4" testmods="allactive/defaultio">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>


### PR DESCRIPTION
Create a first beta release for NorESM2.3

- [x] Update BLOM tag to `v1.6.13`
- [x] Update CAM tag to `cam_noresm2_3_v1.0.0j`
- [x] Update CIME tag to `cime5.6.10_NorESM2_3_r7`

Test results, comparing with `noresm2_3_alpha03` tag:
- [x] prealpha_noresm
    - Expected namelist changes for CAM
    - Expected BLOM namelist changes
    - Baseline differences -- okay?
- [x] aux_cam_noresm
    - Expected namelist changes in CAM
    - Expected baseline changes
- [x] aux_blom_noresm: [3/4] tests PASS
   - Expected FAIL for `ERP_Ld3_P256.T62_tn14.NOINY.betzy_intel`
   - Expected NLFAIL for 3 tests