### PR TITLE
noresm3_0_beta10a

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@ fxDONOTUSEurl = https://github.com/NCAR/ParallelIO.git
 [submodule "ccs_config"]
 path = ccs_config
 url = https://github.com/NorESMhub/ccs_config_noresm.git
-fxtag = ccs_config_noresm0.0.55
+fxtag = ccs_config_noresm0.0.56
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/ccs_config_noresm.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,50 @@
 ==============================================================
 
+Tag name: noresm3_0_beta10a
+Date: 21.01.2026
+One-line Summary: Update Olivia settings
+
+Details:
+ - Update ccs_config to ccs_config_noresm0.0.56
+
+Component tags used in this tag:
+
+ - parallelio : NCAR/ParallelIO             : pio2_6_2
+ - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.56
+ - cime       : NorESMhub/cime              : cime6.1.143_noresm_v1
+ - share      : NorESMHub/NorESM_share      : share1.1.9_noresm_v0
+ - blom       : NorESMhub/BLOM              : v1.12.23
+ - cam        : NorESMhub/CAM               : noresm3_0_024_cam6_4_121
+ - cdeps      : NorESMhub/CDEPS             : cdeps1.0.87_noresm_v3
+ - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_1_20251129_v1
+ - cism       : NorESMhub/CISM-wrapper      : cismwrap_2_2_007_noresm_v1
+ - clm        : NorESMhub/CTSM              : ctsm5.4.002_noresm_v1
+    - fates   : NorESMhub/fates             : sci.1.88.6_api.42.0.0_nor_sci1_api1
+ - cmeps      : NorESMhub/CMEPS             : cmeps1.1.23_noresm_v1
+ - mosart     : NorESMhub/MOSART            : mosart1.1.12_noresm_v1
+ - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.18
+ - pycect     : NCAR/PyCECT                 : 3.2.2
+
+Bugs fixed:
+
+Describe any changes made to scripts/build system: NA
+
+Describe any substantial timing or memory changes: NA
+
+Code merged by: Tomas Torsvik
+
+Code reviewed by: Mariana Vertenstein, Steve Goldhaber, mvdebolskiy, Alok Gupta
+
+Summary of pre-tag testing:
+ - prealpha_noresm :
+ - aux_blom_noresm :
+ - aux_cam_noresm :
+ - aux_clm_noresm :
+
+Summarize any change to answers:
+
+==============================================================
+
 Tag name: noresm3_0_beta10
 Date: 20.01.2026
 One-line Summary: New CAM capability for co2 ffuel, co2 aircraft and nitrogen deposition


### PR DESCRIPTION
PR for _noresm3_0_beta10a_

> Each tag should preferably only include major updates from one component (e.g. include large code 
> changes from upstream repositories, large structural changes, new (default) model capability).
> Minor component updates can be included in addition, if they do not change model output substantially.


**Main objective:** (TBD)

update OLIVIA settings - run DEBUG mode out-of-the-box (ccs_config?)

**Components:**

> Checkmarked components are already latest version, and will not be updated in this tag.
> - If a component needs an update, remove check-mark and edit tag name to the new one that will be used.
> - If appropriate, also include link to resolved issues/PRs as sub-list under the relevant component.
> - At PR stage, check-mark components after testing is completed.

 - [x] parallelio: `pio2_6_2`
 - [x] ccs_config: `ccs_config_noresm0.0.56` 
 - [x] cime: `cime6.1.143_noresm_v1`
 - [x] share: `share1.1.9_noresm_v0`
 - [x] BLOM: `v1.12.23`
 - [x] CAM: `noresm3_0_024_cam6_4_121`
 - [x] CDEPS: `cdeps1.0.87_noresm_v3`
 - [x] CICE: `noresm_cice6_6_1_20251129_v1`
 - [x] CISM: `cismwrap_2_2_007_noresm_v1`
 - [x] CLM: `ctsm5.4.002_noresm_v1`
   - [x] FATES: `sci.1.88.6_api.42.0.0_nor_sci1_api1`
 - [x] CMEPS: `cmeps1.1.23_noresm_v1`
 - [x] MOSART: `mosart1.1.12_noresm_v1`
 - [x] WW3: `ww3_interface_noresm0.0.18`
 - [x] pycect: `3.2.2`

**Coupled development**

**Bugs / bug fixes**

**Test procedure for new tags**

This PR does not change anything on Betzy, as only Olivia settings are affected. Currently we have not added support for Olivia in the test suites (Will add with this PR?)
- Testing to be done after merging.