### PR TITLE
noresm3_0_beta13a: Bugfixes for CTSM (including fix for interim restart writes)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -109,7 +109,7 @@ fxDONOTUSEurl = https://github.com/NorESMhub/CISM-wrapper.git
 [submodule "clm"]
 path = components/clm
 url = https://github.com/NorESMhub/CTSM.git
-fxtag = ctsm5.4.002_noresm_v4
+fxtag = ctsm5.4.002_noresm_v6
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/CTSM.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@ Component tags used in this tag:
 
 Bugs fixed:
  - NorESMhub/NorESM#790
+ - NorESMhub/CTSM#204
  - historical runs with fates crash with DEBUG=TRUE
 
 Describe any changes made to scripts/build system: NA

--- a/ChangeLog
+++ b/ChangeLog
@@ -39,14 +39,14 @@ Describe any changes made to scripts/build system: NA
 
 Describe any substantial timing or memory changes: NA
 
-Code merged by: Mariana Vertenstein
+Code merged by: mvdebolskiy
 
-Code reviewed by: Tomas Torsvik, Steve Goldhaber, Mats Bentsen
+Code reviewed by:  Steve Goldhaber, Mariana Vertenstein
 
 Summary of pre-tag testing on Betzy:
- - prealpha_noresm : PASS, no DIFFs compared to noresm3_0_beta12a
- - aux_clm_noresm : PASS, no DIFFs compared to noresm3_0_beta12a
-   - All tests that WW3 tests
+ - prealpha_noresm : PASS, no DIFFs compared to noresm3_0_beta13
+ - aux_clm_noresm : PASS, no DIFFs compared to noresm3_0_beta13
+
 
 Summary of pre-tag testing on Olivia:
  - prealpha_noresm : NA (system down for maintenance)

--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@ Component tags used in this tag:
 
 Bugs fixed:
  - NorESMhub/NorESM#790
+ - NorESMhub/NorESM#670
  - NorESMhub/CTSM#204
  - historical runs with fates crash with DEBUG=TRUE
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,59 @@
 ==============================================================
 
+Tag name: noresm3_0_beta13a
+Date: 15.04.2026
+One-line Summary: Bugfixes for CTSM
+
+Details:
+- Update CTSM to ctsm5.4.002_noresm_v6
+  - fix for irrigate=true with fates
+  - fix for restart at year boundary
+
+
+
+Component tags used in this tag:
+
+ - parallelio : NCAR/ParallelIO             : pio2_6_2
+ - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.63
+ - cime       : NorESMhub/cime              : cime6.1.143_noresm_v1
+ - share      : NorESMHub/NorESM_share      : share1.1.18_noresm_v0
+ - blom       : NorESMhub/BLOM              : v1.12.36
+ - cam        : NorESMhub/CAM               : noresm3_0_027_cam6_4_121
+ - cdeps      : NorESMhub/CDEPS             : cdeps1.0.88_noresm_v1
+ - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_1_20251129_v2
+ - cism       : NorESMhub/CISM-wrapper      : cismwrap_2_2_007_noresm_v1
+ - clm        : NorESMhub/CTSM              : ctsm5.4.002_noresm_v6
+    - fates   : NorESMhub/fates             : sci.1.88.6_api.42.0.0_nor_sci5_api1
+ - cmeps      : NorESMhub/CMEPS             : cmeps1.1.41_noresm_v0
+ - mosart     : NorESMhub/MOSART            : mosart1.1.12_noresm_v2
+ - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.18
+ - pycect     : NCAR/PyCECT                 : 3.2.2
+
+Bugs fixed:
+ - NorESMhub/NorESM#790
+ - historical runs with fates crash with DEBUG=TRUE
+
+Describe any changes made to scripts/build system: NA
+
+Describe any substantial timing or memory changes: NA
+
+Code merged by: Mariana Vertenstein
+
+Code reviewed by: Tomas Torsvik, Steve Goldhaber, Mats Bentsen
+
+Summary of pre-tag testing on Betzy:
+ - prealpha_noresm : PASS, no DIFFs compared to noresm3_0_beta12a
+ - aux_clm_noresm : PASS, no DIFFs compared to noresm3_0_beta12a
+   - All tests that WW3 tests
+
+Summary of pre-tag testing on Olivia:
+ - prealpha_noresm : NA (system down for maintenance)
+
+Summarize any change to answers:
+  - No answer changes in tests. Slight answer changes in simulations with restart
+
+==============================================================
+
 Tag name: noresm3_0_beta13
 Date: 15.04.2026
 One-line Summary: Updates to CMEPS, share


### PR DESCRIPTION
Updates for components:
 - [x] CLM: `ctsm5.4.002_noresm_v6`
   - [x] FATES: `sci.1.88.6_api.42.0.0_nor_sci5_api1`

**Coupled development**

**Bugs / bug fixes**
 - #790 
 - many issues with HIST_ runs with FATES.
**Test procedure for new tags**
 - [x] `prealpha_noresm` (betzy):
 - [x] `aux_clm_noresm`  (betzy):

fixes #790 
fixes #670
closes #785 