### PR TITLE
noresm3_0_beta13b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,7 +74,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share.git
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = v1.12.36
+fxtag = v1.12.39
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,57 @@
 ==============================================================
 
+Tag name: noresm3_0_beta13b
+Date: 21.04.2026
+One-line Summary: Bugfix for BLOM
+
+Details:
+- Update BLOM to v1.12.39
+  - v1.12.37: Make extNcycle support optional natDIC tracers
+  - v1.12.38: Adjust ocprod natcalc deposition
+  - v1.12.39: Work-around for writing atmospheric CO2
+
+Component tags used in this tag:
+
+ - parallelio : NCAR/ParallelIO             : pio2_6_2
+ - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.63
+ - cime       : NorESMhub/cime              : cime6.1.143_noresm_v1
+ - share      : NorESMHub/NorESM_share      : share1.1.18_noresm_v0
+ - blom       : NorESMhub/BLOM              : v1.12.39
+ - cam        : NorESMhub/CAM               : noresm3_0_027_cam6_4_121
+ - cdeps      : NorESMhub/CDEPS             : cdeps1.0.88_noresm_v1
+ - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_1_20251129_v2
+ - cism       : NorESMhub/CISM-wrapper      : cismwrap_2_2_007_noresm_v1
+ - clm        : NorESMhub/CTSM              : ctsm5.4.002_noresm_v6
+    - fates   : NorESMhub/fates             : sci.1.88.6_api.42.0.0_nor_sci5_api1
+ - cmeps      : NorESMhub/CMEPS             : cmeps1.1.41_noresm_v0
+ - mosart     : NorESMhub/MOSART            : mosart1.1.12_noresm_v2
+ - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.18
+ - pycect     : NCAR/PyCECT                 : 3.2.2
+
+Bugs fixed:
+ - NorESMhub/NorESM#796
+
+Describe any changes made to scripts/build system: NA
+
+Describe any substantial timing or memory changes: NA
+
+Code merged by: Tomas Torsvik
+
+Code reviewed by:  Mats Bentsen, Jörg Schwinger
+
+Summary of pre-tag testing on Betzy:
+ - prealpha_noresm : PASS, no DIFFs compared to noresm3_0_beta13
+   - NLFAIL when setting reduced output for BLOM/iHAMOCC
+ - aux_blom_noresm : PASS, no DIFFs compared to noresm3_0_beta13
+
+Summary of pre-tag testing on Olivia:
+ - prealpha_noresm : NA (system down for maintenance)
+
+Summarize any change to answers:
+  - No answer changes in tests.
+
+==============================================================
+
 Tag name: noresm3_0_beta13a
 Date: 15.04.2026
 One-line Summary: Bugfixes for CTSM


### PR DESCRIPTION
Planned for _noresm3.0.beta13b_

> Each tag should preferably only include major updates from one component (e.g. include large code 
> changes from upstream repositories, large structural changes, new (default) model capability).
> Minor component updates can be included in addition, if they do not change model output substantially.


**Main objective:** Bugfix for BLOM
- Update BLOM to v1.12.39
  - Bugfix for #796 

**Components:**

> Checkmarked components are already latest version, and will not be updated in this tag.
> - If a component needs an update, remove check-mark and edit tag name to the new one that will be used.
> - If appropriate, also include link to resolved issues/PRs as sub-list under the relevant component.
> - At PR stage, check-mark components after testing is completed.

 - [x] parallelio: `pio2_6_2`
 - [x] ccs_config: `ccs_config_noresm0.0.63`
 - [x] cime: `cime6.1.143_noresm_v1`
 - [x] share: `share1.1.18_noresm_v0`
 - [x] BLOM: `v1.12.39`
 - [x] CAM: `noresm3_0_027_cam6_4_121`
 - [x] CDEPS: `cdeps1.0.88_noresm_v1`
 - [x] CICE: `noresm_cice6_6_1_20251129_v2`
 - [x] CISM: `cismwrap_2_2_007_noresm_v1`
 - [x] CLM: `ctsm5.4.002_noresm_v4`
   - [x] FATES: `sci.1.88.6_api.42.0.0_nor_sci5_api1`
 - [x] CMEPS: `cmeps1.1.41_noresm_v0`
 - [x] MOSART: `mosart1.1.12_noresm_v2`
 - [x] WW3: `ww3_interface_noresm0.0.18`
 - [x] pycect: `3.2.2`

**Coupled development**

**Bugs / bug fixes**

**Test procedure for new tags**
 - [x] `prealpha_noresm` (betzy):
 - [ ] `prealpha_noresm` (olivia):
 - [x] `aux_blom_noresm` (betzy):
 - [ ] `aux_hamocc_noresm` (betzy):

**New baseline simulations**
 - [ ] `prealpha_noresm` (betzy/olivia)
 - [ ] `aux_blom_noresm` (betzy)
 - [ ] `aux_hamocc_noresm` (betzy)
 - [ ] `aux_cice_noresm` (betzy)


