### PR TITLE
noresm3_0_beta16

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -109,7 +109,7 @@ fxDONOTUSEurl = https://github.com/NorESMhub/CISM-wrapper.git
 [submodule "clm"]
 path = components/clm
 url = https://github.com/NorESMhub/CTSM.git
-fxtag = ctsm5.4.002_noresm_v7
+fxtag = ctsm5.4.036_noresm_v0
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/CTSM.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,72 @@
 
 Tag name: noresm3_0_beta15
 Date:
+One-line Summary: Updates to CTSM and FATES
+
+Details:
+- CTSM update to ctsm5.4.036_noresm_v0
+  - Changes to defaults:
+    - paramfile: lnd/clm2/paramdata/ctsm60_params.noresm.c260406.nc
+    - fates_paramfile: src/fates/parameter_files/fates_params_noresm.json
+    - filled nans in the surface and other datasets for ifx compiler to be happy
+    - new namelist flag for initializing fates at coldstart with dbh instead of density
+  - Updates to fate landuse and bugfixes
+  - carbon+nitrogen coupling with fates.
+  - FATES: update to sci.1.92.4_api.45.0.0_nor_sci1_api1
+    - fates_paramfile is now in .json format and lives in:
+      in LNDROOT/src/fates/parameter_files/ by default.
+    - Updates and fixes for landuse
+    - Refactory for cn-coupling
+    - added 15th PFT (generic crop)
+
+Component tags used in this tag:
+
+ - parallelio : NCAR/ParallelIO             : pio2_6_2
+ - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.65
+ - cime       : NorESMhub/cime              : cime6.1.173_noresm_v0
+ - share      : NorESMHub/NorESM_share      : share1.1.18_noresm_v0
+ - blom       : NorESMhub/BLOM              : v1.12.39
+ - cam        : NorESMhub/CAM               : noresm3_0_032_cam6_4_121
+ - cdeps      : NorESMhub/CDEPS             : cdeps1.0.88_noresm_v2
+ - cice6      : NorESMhub/NorESM_CICE       : noresm_cice6_6_1_20251129_v2
+ - cism       : NorESMhub/CISM-wrapper      : cismwrap_2_2_007_noresm_v1
+ - clm        : NorESMhub/CTSM              : ctsm5.4.036_noresm_v0
+    - fates   : NorESMhub/fates             : sci.1.92.4_api.45.0.0_nor_sci1_api1
+ - cmeps      : NorESMhub/CMEPS             : cmeps1.1.41_noresm_v0
+ - mosart     : NorESMhub/MOSART            : mosart1.1.12_noresm_v2
+ - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.18
+ - pycect     : NCAR/PyCECT                 : 3.2.2
+
+Bugs fixed: swap pasture and rangeland names in the luh 
+
+Describe any changes made to scripts/build system: 
+  - Any manipulations with fates_paramfile has to be updated
+  - initial dataset won't be valid. You can not restart/initialize land with files from previous versions
+
+Describe any substantial timing or memory changes: NA
+
+Code merged by: mvdebolskiy
+
+Code reviewed by: 
+
+Summary of pre-tag testing on Betzy:
+ - prealpha_noresm : PASS expected FAILS for ERS for N1850G and NHistG
+ - aux_clm_noresm : PASS, FatesIniSpinup fails due to lack of new finidat
+ - aux_cam_noresm : outfrq9s_fatesini will fail due to lack of new finidat
+
+Summary of pre-tag testing on Olivia:
+ - prealpha_noresm : new expected FAILS for ERS for N1850G and NHistG
+ - aux_cam_noresm : PASS
+
+Summarize any change to answers:
+ - to be evaluated
+ - DIFFS in all tests with prognostic LND
+
+
+==============================================================
+
+Tag name: noresm3_0_beta15
+Date:
 One-line Summary: New compset aliases and tests for CMIP7 and updates to CAM
 
 Details:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 ==============================================================
 
-Tag name: noresm3_0_beta15
+Tag name: noresm3_0_beta16
 Date:
 One-line Summary: Updates to CTSM and FATES
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -56,8 +56,7 @@ Summary of pre-tag testing on Betzy:
  - aux_cam_noresm : outfrq9s_fatesini will fail due to lack of new finidat
 
 Summary of pre-tag testing on Olivia:
- - prealpha_noresm : new expected FAILS for ERS for N1850G and NHistG
- - aux_cam_noresm : PASS
+
 
 Summarize any change to answers:
  - to be evaluated

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 ==============================================================
 
 Tag name: noresm3_0_beta16
-Date:
+Date: 05.05.2026
 One-line Summary: Updates to CTSM and FATES
 
 Details:
@@ -48,15 +48,18 @@ Describe any substantial timing or memory changes: NA
 
 Code merged by: mvdebolskiy
 
-Code reviewed by: 
+Code reviewed by: mvertens, Tomas Torsvik 
 
 Summary of pre-tag testing on Betzy:
- - prealpha_noresm : PASS expected FAILS for ERS for N1850G and NHistG
- - aux_clm_noresm : PASS, FatesIniSpinup fails due to lack of new finidat
- - aux_cam_noresm : outfrq9s_fatesini will fail due to lack of new finidat
+  - prealpha_noresm : PASS expected COMPARE_base_rest FAILS for ERS for N*G compsets
+  - aux_clm_noresm  : PASS, FatesIniSpinup fails due to lack of new finidat
+  - aux_cam_noresm  : outfrq9s_fatesini will fail due to lack of new finidat
 
 Summary of pre-tag testing on Olivia:
-
+  - prealpha_noresm : PASS expected COMAPRE_base_rest FAILS fpr ERS for N*G compsets
+  - aux_clm_noresm  : PASS FatesIniSpinup fails due to lack of new finidat
+                      fail in FatesColdPRT2_suplnAll due to ESCOMP/CTSM#3989
+  - aux_cam_noresm  : outfrq9s_fatesini will fail due to lack of new finidat
 
 Summarize any change to answers:
  - to be evaluated

--- a/ChangeLog
+++ b/ChangeLog
@@ -66,7 +66,7 @@ Summarize any change to answers:
 ==============================================================
 
 Tag name: noresm3_0_beta15
-Date:
+Date: 05.05.2026
 One-line Summary: New compset aliases and tests for CMIP7 and updates to CAM
 
 Details:


### PR DESCRIPTION
Planned for _3.0.beta16_

> Each tag should preferably only include major updates from one component (e.g. include large code 
> changes from upstream repositories, large structural changes, new (default) model capability).
> Minor component updates can be included in addition, if they do not change model output substantially.


**Main objective:** (Bring updates from ESCOMP to CTSM)
 
- CTSM
    - Pull latest tag (5.4.036) from ESCOMP
    - Update fates tag and resolve merge conflicts
    - New PFT (crop) added to FATES
    - Convert fates parameter file to .json format

**Components:**

> Checkmarked components are already latest version, and will not be updated in this tag.
> - If a component needs an update, remove check-mark and edit tag name to the new one that will be used.
> - If appropriate, also include link to resolved issues/PRs as sub-list under the relevant component.
> - At PR stage, check-mark components after testing is completed.

 - [x] parallelio: `pio2_6_2`
 - [x] ccs_config: `ccs_config_noresm0.0.65`
 - [x] cime: `cime6.1.173_noresm_v0`
 - [x] share: `share1.1.8_noresm_v0`
 - [x] BLOM: `v1.12.39`
 - [x] CAM: `noresm3_0_032_cam6_4_121`
 - [x] CDEPS: `cdeps1.0.88_noresm_v2`
 - [x] CICE: `noresm_cice6_6_1_20251129_v2`
 - [x] CISM: `cismwrap_2_2_007_noresm_v1`
 - [x] CLM: `ctsm5.4.036_noresm_v0`
   - [x] FATES: `sci.1.92.4_api.45.0.0_nor_sci1_api1`
 - [x] CMEPS: `cmeps1.1.23_noresm_v1`
 - [x] MOSART: `mosart1.1.12_noresm_v2`
 - [x] WW3: `ww3_interface_noresm0.0.18`

**Coupled development**

**Bugs / bug fixes**

**Test procedure and new baselines for tags**

> - All tests should be performed before merging. Only expected failing tests are allowed.
> - If there is a new test that is expected to fail, this should be documented, preferably as
> an issue in the NorESM repository (for prealpha_noresm), or in a component repository.
> - Baselines can be created during this test phase, or after the PR branch has been merged
> and tagged.

 - [x] `prealpha_noresm` (betzy) - @mvdebolskiy  
   - [x] baseline created
 - [x] `prealpha_noresm` (olivia) - @mvdebolskiy 
   - [x] baseline created
 - [x] `aux_clm_noresm` (betzy) - @mvdebolskiy 
   - [x] baseline created
 - [x] `aux_clm_noresm` (olivia) - @mvdebolskiy  
   - [x] baseline created
