### PR TITLE
Update NorESM2.0 infrastructure (non-answer changing updates)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r7
+tag = cime5.6.10_NorESM2.3.0_v3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
These updates are intended for a new tag `release-noresm2.0.11`

- [x] Update cime tag to cime5.6.10_NorESM2.3.0_v4
- [x] Update BLOM tag to v1.4.7
- Sourcemod updates for pacemaker experiments (separate PR following this one)

TODO:
- [x] Test PR branch against `release-noresm2.0.10`
  - tested against `N1850frc2esm_f19_tn14`, output is bit for bit